### PR TITLE
speed up peptide encoding

### DIFF
--- a/pDeep/cmd/tune_and_predict.py
+++ b/pDeep/cmd/tune_and_predict.py
@@ -161,15 +161,19 @@ def tune(param):
     return pdeep, pdeep_RT
      
 def predict(pdeep, param, peptide_list = None):
-    print("[pDeep Info] loading peptides ...")
+    start_time = time.perf_counter()
+    print("[pDeep Info] encoding peptides ...")
     if peptide_list is not None:
         pep_buckets = load_data.load_peptides_as_buckets(peptide_list, param.config, nce=param.predict_nce, instrument=param.predict_instrument)
     else:
         pep_buckets = load_data.load_peptide_file_as_buckets(param.predict_input, param.config, nce=param.predict_nce, instrument=param.predict_instrument)
+    time_now = time.perf_counter()
+    print(f"[pDeep Info] encoding time = {time_now - start_time} seconds")
+
     start_time = time.perf_counter()
     print("[pDeep Info] predicting ...")
     predict_buckets = pdeep.Predict(pep_buckets)
-    print('[pDeep Info] predicting time = {:.3f}s'.format(time.perf_counter() - start_time))
+    print('[pDeep Info] predicting time = {:.3f} seconds'.format(time.perf_counter() - start_time))
     return pep_buckets,predict_buckets
     
 def predict_RT(pdeep_RT, param, pep_buckets):

--- a/pDeep/featurize.py
+++ b/pDeep/featurize.py
@@ -390,8 +390,21 @@ def CheckPeptide(peptide):
             return 0
     return 1
 
+one_hot = np.zeros((128,20),dtype=base_dtype)
+for i,aa in enumerate('ACDEFGHIKLMNPQRSTVWY'):
+    one_hot[ord(aa)][i] = 1
 
-def _seq2vector(peptide, prev, next):
+def _seq2vector(peptide, prev = 1, next = 1):
+    flag = np.zeros((len(peptide)-1,2),dtype=base_dtype)
+    flag[0,0] = 1
+    flag[-1,1] = 1
+    one_hot_peptide = one_hot[[ord(aa) for aa in peptide]]
+    left_sum = np.cumsum(one_hot_peptide,axis=0)
+    right_sum = left_sum[-1] - left_sum
+    result = np.concatenate([one_hot_peptide[:-1,:],one_hot_peptide[1:,:],(left_sum-one_hot_peptide)[0:-1],right_sum[1:],flag],axis=1)
+    return result
+
+def _seq2vector_old(peptide, prev, next):
     x = []
     base_NtermAA_Count = [0] * nAAs
     base_CtermAA_Count = [0] * nAAs


### PR DESCRIPTION
For ecoli fasta, encoding peptides using old codes will take ~150 seconds. With these codes, it takes ~40 seconds.